### PR TITLE
Refactors sourced file contents into functions

### DIFF
--- a/handle_casecontrolse.R
+++ b/handle_casecontrolse.R
@@ -14,7 +14,7 @@ save_results <- function(results, user_email) {
 handle_cc_se <- function(selected_population, user_email, uploaded_data, N_case_se, N_control_se, 
                          OR_colname_se, SE_colname_se, chromosome_colname, position_colname) {
   # Call merge.R final_results function to obtain gnomAD population data
-  super_population_results <- final_results(selected_population)
+  super_population_results <- do_merge(uploaded_data, selected_population)
   selected_MAF_col <- paste0("MAF_", selected_population)
   # Create the correction data dataframe required as an argument for CC_SE function
   corr_data <- data.frame(CHR = as.character(super_population_results$chrom),

--- a/modules/operation_selection.R
+++ b/modules/operation_selection.R
@@ -101,6 +101,7 @@ operationSelectionServer <- function(id, uploaded_data, column_names, main_sessi
       handle_se_process <- callr::r_bg(
         function(selected_population, user_email, uploaded_data, N_case_se, N_control_se, 
                  OR_colname_se, SE_colname_se, chromosome_colname, position_colname) {
+          # FIXME: move this to app.R, and if that doesn't work, then move it back
           source("../CCAFE/handle_casecontrolse.R") # Source the merge.R script
           handle_cc_se(selected_population, user_email, uploaded_data, N_case_se, N_control_se,
                        OR_colname_se, SE_colname_se, chromosome_colname, position_colname)# Execute function

--- a/query.R
+++ b/query.R
@@ -12,70 +12,10 @@ library(ratelimitr)
 #df <- read.delim(file = "/Users/hugolemus/Downloads/pheno_295_EUR.txt.gz", header = TRUE, sep = "\t")
 gnomad_api_url <- Sys.getenv("GNOMAD_API_URL", unset="https://gnomad.broadinstitute.org/api")
 
-# build a connection object to consume gnomad's graphql API
-con <- GraphqlClient$new(
-  url = gnomad_api_url
-)
-
-# build a template for the query with params that we'll provide
-# to the execute_query function
-qry <- Query$new()
-
-# you can visit https://gnomad.broadinstitute.org/api to see the available
-# entities in gnomad. on that site, click the 'Docs' button in the top-right,
-# then click 'Query' in the resulting sidebar, and you'll see the available
-# queryable entities. you can also try out graphql queries against the API on
-# that site.
-
-qry$query(
-  'VariantsInRange',
-  'query($chrom: String!, $start: Int!, $stop: Int!) {
-    region(chrom: $chrom, start: $start, stop: $stop, reference_genome: GRCh38) {
-      chrom, start, stop, reference_genome,
-
-      variants(dataset: gnomad_r4_non_ukb) {
-        chrom
-        pos
-        ref
-        alt
-        genome {
-          populations {
-            id
-            ac
-            an
-            }
-          }
-        }
-      }
-    }'
-)
-
-# create a function to invoke the graphql query.
-# throttle the function to 10 requests per 60 seconds
-# per stated limits at https://gnomad.broadinstitute.org/data#api
-exec_query <- limit_rate(
-  function(args) {
-    
-    tryCatch({
-      x <- con$exec(qry$queries$VariantsInRange, args)
-      return(jsonlite::fromJSON(x))
-    }, error = function(e) {
-      message("Error: ", e$message)
-      # also print the body of the error response
-      message("Response: ", e$response)
-      
-      return(NULL)
-    })
-    # x <- con$exec(qry$queries$VariantsInRange, args)
-    # return(jsonlite::fromJSON(x))
-  },
-  rate(n = 10, period = 60)
-)
-
 # Function to read input file and generate query ranges
-generate_ranges <- function(file_path, range_size = 100000) {
+generate_ranges <- function(data, range_size = 100000) {
   range_size = 100000
-  data <- read.delim(file_path, header = TRUE, sep = "\t")
+  # data <- read.delim(file_path, header = TRUE, sep = "\t")
   #data <- as.data.table(data)
   # Extract unique chromosome and position ranges
   ranges <- data %>%
@@ -119,39 +59,102 @@ generate_ranges <- function(file_path, range_size = 100000) {
   return(ranges)
 }
 
-# Read the provided file and generate ranges
-file_path <- "../CCAFE/uploaded_user_file.text.gz"  # Update this with the correct path
-ranges <- generate_ranges(file_path)
+do_query <- function(uploaded_data) {
+  # build a connection object to consume gnomad's graphql API
+  con <- GraphqlClient$new(
+    url = gnomad_api_url
+  )
 
-# Query gnomAD API for each range and store the results
-full_query_runtime <- system.time({
-  results <- list()
-  for (i in 1:nrow(ranges)) {
-    message("Querying range ", i, " of ", nrow(ranges))
-    args <- list(
-      chrom = as.character(ranges$chrom[i]),
-      start =  as.integer(ranges$start[i]),
-      stop = as.integer(ranges$stop[i])
-    )
-    
-    result <- exec_query(args)
-    if (!is.null(result)) {
-      results[[i]] <- result
+  # build a template for the query with params that we'll provide
+  # to the execute_query function
+  qry <- Query$new()
+
+  # you can visit https://gnomad.broadinstitute.org/api to see the available
+  # entities in gnomad. on that site, click the 'Docs' button in the top-right,
+  # then click 'Query' in the resulting sidebar, and you'll see the available
+  # queryable entities. you can also try out graphql queries against the API on
+  # that site.
+
+  qry$query(
+    'VariantsInRange',
+    'query($chrom: String!, $start: Int!, $stop: Int!) {
+      region(chrom: $chrom, start: $start, stop: $stop, reference_genome: GRCh38) {
+        chrom, start, stop, reference_genome,
+
+        variants(dataset: gnomad_r4_non_ukb) {
+          chrom
+          pos
+          ref
+          alt
+          genome {
+            populations {
+              id
+              ac
+              an
+              }
+            }
+          }
+        }
+      }'
+  )
+
+  # create a function to invoke the graphql query.
+  # throttle the function to 10 requests per 60 seconds
+  # per stated limits at https://gnomad.broadinstitute.org/data#api
+  exec_query <- limit_rate(
+    function(args) {
+      
+      tryCatch({
+        x <- con$exec(qry$queries$VariantsInRange, args)
+        return(jsonlite::fromJSON(x))
+      }, error = function(e) {
+        message("Error: ", e$message)
+        # also print the body of the error response
+        message("Response: ", e$response)
+        
+        return(NULL)
+      })
+      # x <- con$exec(qry$queries$VariantsInRange, args)
+      # return(jsonlite::fromJSON(x))
+    },
+    rate(n = 10, period = 60)
+  )
+
+  # Read the provided file and generate ranges
+  # file_path <- "../CCAFE/uploaded_user_file.text.gz"  # Update this with the correct path
+  ranges <- generate_ranges(uploaded_data)
+
+  # Query gnomAD API for each range and store the results
+  full_query_runtime <- system.time({
+    results <- list()
+    for (i in 1:nrow(ranges)) {
+      message("Querying range ", i, " of ", nrow(ranges))
+      args <- list(
+        chrom = as.character(ranges$chrom[i]),
+        start =  as.integer(ranges$start[i]),
+        stop = as.integer(ranges$stop[i])
+      )
+      
+      result <- exec_query(args)
+      if (!is.null(result)) {
+        results[[i]] <- result
+      }
     }
-  }
-})
-# Display system run time for query 
-print(full_query_runtime)
+  })
 
-# Combine all variant query results from all generated range values
-query_results <- bind_rows(lapply(results, function(res){
-  if (!is.null(res$data$region$variants)) {
-    variants <- as.data.frame(res$data$region$variants)
-    #return(variants)
-  } else {
-    NULL
-  }
-}))
+  # Display system run time for query 
+  print(full_query_runtime)
 
-# Start merging process here
-# Here we can apply a function where from the query we only extract the variants in the uploaded file before further processing
+  # Combine all variant query results from all generated range values
+  query_results <- bind_rows(lapply(results, function(res){
+    if (!is.null(res$data$region$variants)) {
+      variants <- as.data.frame(res$data$region$variants)
+      #return(variants)
+    } else {
+      NULL
+    }
+  }))
+
+  # Start merging process here
+  # Here we can apply a function where from the query we only extract the variants in the uploaded file before further processing
+}

--- a/upload.R
+++ b/upload.R
@@ -106,13 +106,15 @@ upload_file <- function(file, file_name, file_path) {
 }
 
 
-save_file <- function(file_data, output_dir = "/tmp/CCAFE/", output_name = "uploaded_user_file.text.gz") {
+save_file <- function(file_data, output_dir = "/tmp/CCAFE/") {
   # ensure the output folder exists
   if (!dir.exists(output_dir)) {
     dir.create(output_dir)
   }
 
-  new_path <- file.path(output_dir, output_name)
+  # creates a randomly-named file under output_dir (i.e., /tmp/CCAFE/)
+  # which ensures the file won't collide with others' uploaded files
+  new_path <- tempfile(tmpdir=output_dir)
   fwrite(file_data, new_path, sep = "\t", compress = "gzip")
   return(new_path)
 }


### PR DESCRIPTION
This PR wraps the statements in the files `merge.R` and `query.R` in functions, so that they can be run independently of when the file is sourced. The PR also refactors how the initial uploaded data is treated; instead of being parsed from a hardcoded path, it's instead parsed once and then passed as a dataframe to each method that relies on it.

Refactoring the statements in those files into functions provides greater control over when the code in those files actually runs, i.e. when the function is called rather than when the file is sourced. Importantly, it also formalizes the interface between the code and the caller: rather than expecting certain variables to be set before the code runs, those values are instead passed in as arguments, and rather than the caller having to expect variables to be set after the code runs, those values are instead returned from the functions. (While I'm unsure if this pattern holds in R, in Python these statements outside of functions are called "module import side-effects" and are generally avoided so that one can treat the modules as libraries rather than scripts.)

