### PR TITLE
Moves secrets into env file

### DIFF
--- a/.env.TEMPLATE
+++ b/.env.TEMPLATE
@@ -1,0 +1,4 @@
+MAILGUN_API_KEY=<your_api_key_here>
+MAILGUN_DOMAIN=<your_domain_here>
+
+MAILGUN_FROM="CCAFE Admin <mailgun@${MAILGUN_DOMAIN}>"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 .DS_Store
 
 app_cache
+
+.env

--- a/README.rst
+++ b/README.rst
@@ -9,3 +9,7 @@ This `GitHub Page <https://ccafe-app.readthedocs.io/en/latest/>`_ serves to reco
 development for the `Case and Control Allele Frequency Estimation <https://wolffha.github.io/CCAFE_documentation/>`_
 public application. It includes a detailed proposal and revised documentaion that will be continuesly updated as the
 project develops.
+
+# Getting Started
+
+Copy `.env.TEMPLATE` as `.env` and fill in any empty values with your information.

--- a/app.R
+++ b/app.R
@@ -19,6 +19,9 @@ library(stats)
 library(tidyr)
 library(tools)
 library(vcfR)
+library(dotenv)
+
+load_dot_env()
 
 # Source modules
 source("modules/file_upload.R")

--- a/email.R
+++ b/email.R
@@ -1,14 +1,14 @@
 library(httr)
 
 send_email <- function(email, file_path) {
-  mailgun_api_key <- "738998600f5aa915924b34c23c322c35-1654a412-df26eefd"
-  domain <- "sandbox6c200fba09cb40fabfef60ca08251446.mailgun.org"
+  mailgun_api_key <- Sys.getenv("MAILGUN_API_KEY")
+  domain <- Sys.getenv("MAILGUN_DOMAIN")
   
   res <- POST(
     url = paste0("https://api.mailgun.net/v3/", domain, "/messages"),
     authenticate("api", mailgun_api_key),
     body = list(
-      from = "Excited User <mailgun@sandbox6c200fba09cb40fabfef60ca08251446.mailgun.org>",
+      from = Sys.getenv("MAILGUN_FROM"),
       to = email,
       subject = "Your CaseControl_SE Results",
       text = "Attached are your results.",

--- a/renv.lock
+++ b/renv.lock
@@ -520,6 +520,13 @@
       ],
       "Hash": "33698c4b3127fc9f506654607fb73676"
     },
+    "dotenv": {
+      "Package": "dotenv",
+      "Version": "1.0.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "7e1213a65b6190437c644a14ec814ef3"
+    },
     "dplyr": {
       "Package": "dplyr",
       "Version": "1.1.4",


### PR DESCRIPTION
Previously, certain secrets were hardcoded into the source code, which made them visible to anyone with access to the code. This PR moves those secrets into a `.env` file that's explicitly excluded from being checked in via the `.gitignore` file. Using the [dotenv](https://cran.r-project.org/web/packages/dotenv/index.html) package, the `.env` file is read  into the environment when the app boots, where its contents can then be safely retrieved and used via the `Sys.getenv()` method.

The PR replaces the hardcoded API keys and other values used when sending emails with values read from the `.env` file. It also adds a `.env.TEMPLATE` file that describes the structure, but doesn't include the secrets of the `.env` file, and adds instructions in the `README` on how to create the `.env` file from that template.