### PR TITLE
Relative paths fix

### DIFF
--- a/app/logic/email.R
+++ b/app/logic/email.R
@@ -41,10 +41,10 @@ send_email <- function(email, file_path) {
   )
   
   if (status_code(res) == 200) {
-    print(paste("Email sent to:", email))
+    message(paste("Email sent to:", email))
     return(TRUE)
   } else {
-    print("Email sending failed.")
+    message("Email sending failed.")
     return(FALSE)
   }
 }

--- a/app/logic/email.R
+++ b/app/logic/email.R
@@ -4,14 +4,22 @@ box::use(
 )
 
 save_results <- function(results, user_email) {
+  # build path to results as subdirectory of app root
+  results_dir <- file.path(Sys.getenv("APP_ROOT", unset="../CCAFE"), "results")
+
+  # ensure the results path exists, creating it if necessary
+  if (!dir.exists(results_dir)) {
+    dir.create(results_dir, recursive = TRUE)
+  }
+
   timestamp <- format(Sys.time(), "%Y%m%d_%H%M%S")
-  file_path <- paste0("../CCAFE/results_", timestamp, ".text.gz") # change file path as needed
+  file_path <- file.path(results_dir, paste0("results_", timestamp, ".text.gz")) # change file path as needed
   
   fwrite(results, file_path, sep = "\t", compress = "gzip")
   
   # Store metadata (email, file path) for later retrieval
   metadata <- data.frame(email = user_email, file = file_path, timestamp = Sys.time())
-  utils::write.csv(metadata, "../CCAFE/results_metadata.csv", row.names = FALSE, append = TRUE) #change file path as needed
+  utils::write.csv(metadata, file.path(results_dir, "results_metadata.csv"), row.names = FALSE, append = TRUE) #change file path as needed
 }
 
 send_email <- function(email, file_path) {

--- a/app/logic/handle_se.R
+++ b/app/logic/handle_se.R
@@ -42,7 +42,7 @@ handle_se <- function(selected_population, user_email, uploaded_data, N_case_se,
   )
   
   save_results(results_se, user_email)
-  print("Saved SE results")
+  message("Saved SE results")
   
   # Read stored metadata
   results_dir <- file.path(Sys.getenv("APP_ROOT", unset="../CCAFE"), "results")
@@ -61,7 +61,7 @@ handle_se <- function(selected_population, user_email, uploaded_data, N_case_se,
       if (send_email(email, file_path)) {
         # Delete the file after successful email
         file.remove(file_path)
-        print(paste("Deleted file:", file_path))
+        message(paste("Deleted file:", file_path))
         
         # Remove entry from metadata
         entries_to_keep <- entries_to_keep[-i, ]
@@ -73,5 +73,5 @@ handle_se <- function(selected_population, user_email, uploaded_data, N_case_se,
   }
   
   return(results_se)
-  print("ControlCase_SE method was executed successfully!")
+  message("ControlCase_SE method was executed successfully!")
 }

--- a/app/logic/handle_se.R
+++ b/app/logic/handle_se.R
@@ -45,7 +45,8 @@ handle_se <- function(selected_population, user_email, uploaded_data, N_case_se,
   print("Saved SE results")
   
   # Read stored metadata
-  metadata_file <- "../CCAFE/results_metadata.csv"
+  results_dir <- file.path(Sys.getenv("APP_ROOT", unset="../CCAFE"), "results")
+  metadata_file <- file.path(results_dir, "results_metadata.csv")
   metadata <- utils::read.csv(metadata_file)
   
   # Only run when there are entries in metadata

--- a/app/logic/merge.R
+++ b/app/logic/merge.R
@@ -109,7 +109,7 @@ do_merge <- function(uploaded_data, user_selected_population) {
   final_merge <- final_merge[ , -((start_col + 1):(end_col - 1)), drop = FALSE]
   
   maf_column <- paste0("MAF_", user_selected_population)
-  # print(af_column)
+  # message(af_column)
   final_merge <- final_merge[final_merge[[maf_column]] > 0.01, ]
   return(final_merge)
 }

--- a/app/logic/query.R
+++ b/app/logic/query.R
@@ -146,7 +146,7 @@ do_query <- function(uploaded_data) {
   })
 
   # Display system run time for query 
-  print(full_query_runtime)
+  message(full_query_runtime)
 
   # Combine all variant query results from all generated range values
   query_results <- bind_rows(lapply(results, function(res){

--- a/app/view/operation_selection.R
+++ b/app/view/operation_selection.R
@@ -372,39 +372,39 @@ operationSelectionServer <- function(id, main_session) {
                     OR_colname_se, SE_colname_se, chromosome_colname, position_colname), 
         supervise = TRUE
       )
-      print(processx::poll(list(handle_se_process), 1000))
+      message(processx::poll(list(handle_se_process), 1000))
       # Poll for completion of merge process
       observe({
         if (handle_se_process$poll_io(0)["process"] != "ready") {
           # If process is still running, don't do anything yet
-          print("still querying...")
-          print(processx::poll(list(handle_se_process), 60000))
-          print(handle_se_process$get_exit_status())
-          print(handle_se_process$read_error())
-          print(handle_se_process$read_output())
+          message("still querying...")
+          message(processx::poll(list(handle_se_process), 60000))
+          message(handle_se_process$get_exit_status())
+          message(handle_se_process$read_error())
+          message(handle_se_process$read_output())
           showNotification("Still querying...", type = "message")
           invalidateLater(60000, session) # Poll every minute
           # Navigate to the email input page
         } else {
-          print("completed query succesful...")
-          print(handle_se_process$get_exit_status())
+          message("completed query succesful...")
+          message(handle_se_process$get_exit_status())
           # Process completed
           if (handle_se_process$get_exit_status() == 0) {
-            print("Completed querying data and running CaseControl_SE()")
+            message("Completed querying data and running CaseControl_SE()")
             results_se <- handle_se_process$get_result()
-            # print(str(results_se))
+            # message(str(results_se))
             results(results_se)
             
             shinyjs::hide("data_preview")
             shinyjs::show("results_preview")
             show_results(TRUE)
             # Notify the user and allow navigation to the next step
-            print("ControlCase_SE method was executed successfully!")
+            message("ControlCase_SE method was executed successfully!")
             # showNotification("Process completed successfully!", type = "message")
             
           } else {
             # Handle errors
-            print("Error occurred after querying and merging was finished, did not go into CC_SE")
+            message("Error occurred after querying and merging was finished, did not go into CC_SE")
             # showNotification("Error occurred during processing.", type = "error")
           }
         }

--- a/app/view/operation_selection.R
+++ b/app/view/operation_selection.R
@@ -364,7 +364,7 @@ operationSelectionServer <- function(id, main_session) {
                  OR_colname_se, SE_colname_se, chromosome_colname, position_colname) {
           # FIXME: move this to app.R, and if that doesn't work, then move it back
           # Source the merge.R script
-          source("../CCAFE/app/logic/handle_se.R")
+          source(file.path(Sys.getenv("APP_ROOT", unset="../CCAFE"), "app/logic/handle_se.R"))
           handle_se(selected_population, user_email, uploaded_data, N_case_se, N_control_se,
                     OR_colname_se, SE_colname_se, chromosome_colname, position_colname) # Execute function
         }, 

--- a/run_app.sh
+++ b/run_app.sh
@@ -11,10 +11,11 @@
 # http://localhost:3850/ccafe/
 
 IMAGE_TAG=latest
-IMAGE=ccafe_app:${IMAGE_TAG}
+IMAGE=us-central1-docker.pkg.dev/cuhealthai-sandbox/hendrickslab/ccafe_app:${IMAGE_TAG}
 
 docker build --platform linux/amd64 -f ./docker/Dockerfile -t ${IMAGE} . &&
 docker run  --platform linux/amd64 --name ccafe_app --rm -it \
     -p 3850:3838 \
     -v $(pwd):/srv/shiny-server/app/ \
+    -e APP_ROOT=/srv/shiny-server/app \
     ${IMAGE}


### PR DESCRIPTION
Prior to this PR, there were a few instances in the codebase of paths to the source root being constructed relatively, e.g. `../CCAFE/<path to file under the source root>`. While these may work locally when the cloned name of the folder is `CCAFE`, these paths were failing when the app was run in a container with the source under a different folder.

This PR introduced the environment variable `APP_ROOT` which specifies the absolute location of the source root in its current environment. The places where paths were being constructed using the relative path `../CCAFE/` now construct their path by concatenating `APP_ROOT`'s value with the path relative to the source root. If `APP_ROOT` is unspecified, those paths default to attempting to construct a relative path using `../CCAFE`.

The PR adds a few other minor fixes:
- creates a `results` folder under the source root and places result files in there
- updates the `IMAGE` variable in the `run_app.sh` script to reflect where the image is stored remotely